### PR TITLE
fixing handlebars module declaration for runtime version

### DIFF
--- a/types/handlebars/index.d.ts
+++ b/types/handlebars/index.d.ts
@@ -338,6 +338,6 @@ declare module "handlebars" {
     export = Handlebars;
 }
 
-declare module "handlebars/handlebars.runtime" {
+declare module "handlebars/runtime" {
     export = Handlebars;
 }


### PR DESCRIPTION
Was done according to the file structure in handlebars' npm package. the filename is runtime.js, handlebars.runtime results in error unless forced as alias.
See also - https://github.com/DefinitelyTyped/DefinitelyTyped/issues/19441 .

- [x ] Provide a URL to documentation or source code which provides context for the suggested changes: https://github.com/wycats/handlebars.js/ , see runtime.js (which is the file referenced here)
